### PR TITLE
Add Heroku deployment button

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ rails s
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
+## Deployment
+
+You can host your own instance of GitHub Inbox using Heroku.
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 ## Copyright
 
 Copyright (c) 2016 Andrew Nesbitt. See [LICENSE](https://github.com/andrew/github-inbox/blob/master/LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Github Inbox &#128238;
+# GitHub Inbox &#128238;
 
 Take back control of your GitHub Notifications
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,17 @@
+{
+  "name": "GitHub Inbox",
+  "description": "Take back control of your GitHub Notifications",
+  "repository": "https://github.com/andrew/github-inbox",
+  "scripts": {
+    "postdeploy": "bundle exec rake db:migrate"
+  },
+  "env": {
+    "GITHUB_TOKEN": {
+      "Your personal GitHub Access Token",
+      "required": true
+    }
+  },
+  "addons": [
+    "heroku-postgresql"
+  ]
+}


### PR DESCRIPTION
Closes #2 

This adds a basic `app.json` file for deployment along with a button on the README to deploy the application.

## Note
It might be preferable to wait on #3 to be resolved first due to the fact that the required environment variables will change (token to OAuth client and secret).