### PR TITLE
Mobile style fixes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,3 +20,10 @@ html {
 .label-muted{
   background-color: #ccc;
 }
+
+.table-responsive {
+  border: 0;
+}
+
+
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,7 @@
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -15,7 +15,7 @@
 </nav>
 <div class="container-fluid">
   <div class="row">
-    <div class="col-md-2 table-responsive">
+    <div class="col-xs-12 col-md-2 table-responsive">
       <table class='table table-condensed'>
         <% @statuses.each do |status, count| %>
           <tr>
@@ -100,7 +100,7 @@
         </tr>
       </table>
     </div>
-    <div class="col-md-10 table-responsive">
+    <div class="col-xs-12 col-md-10 table-responsive">
       <table class='table table-condensed table-hover'>
         <% if @notifications.any? %>
           <%= render @notifications %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -15,7 +15,7 @@
 </nav>
 <div class="container-fluid">
   <div class="row">
-    <div class="col-md-2">
+    <div class="col-md-2 table-responsive">
       <table class='table table-condensed'>
         <% @statuses.each do |status, count| %>
           <tr>
@@ -100,7 +100,7 @@
         </tr>
       </table>
     </div>
-    <div class="col-md-10">
+    <div class="col-md-10 table-responsive">
       <table class='table table-condensed table-hover'>
         <% if @notifications.any? %>
           <%= render @notifications %>


### PR DESCRIPTION
Here's some tweaks for mobile styles, cos you asked for 'em in #15.

A note: responsive layouts and tables go together like peanut butter and orca whales. As you're using them partly to display tabular data and partly to layout things like checkboxes and what-have-you, there isn't really anything I could just "drop in" here to clean things up, thus the table has this kinda unsightly scrolling behaviour on mobile. 

What I've committed here at least gets the ball rolling. For future improvements on mobile, [this might be a good starting point](https://responsivedesign.is/resources/data-tables).